### PR TITLE
fix(install): support flat windows archive

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -80,9 +80,16 @@ if (-not $SkipChecksum) {
 
 Write-Host "=> Extracting..."
 Expand-Archive -Path $ArchivePath -DestinationPath $TmpDir -Force
-$Binary = [System.IO.Path]::Combine($TmpDir, "zv-$Target", 'zv.exe')
-if (-not (Test-Path $Binary)) {
-    Write-Host "Binary not found in archive (expected zv-$Target\zv.exe)" -ForegroundColor Red
+$BinaryCandidates = @(
+    [System.IO.Path]::Combine($TmpDir, "zv-$Target", 'zv.exe'),
+    [System.IO.Path]::Combine($TmpDir, 'zv.exe')
+)
+$Binary = $BinaryCandidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+if (-not $Binary) {
+    Write-Host "Binary not found in archive. Tried:" -ForegroundColor Red
+    $BinaryCandidates | ForEach-Object {
+        Write-Host "  $_" -ForegroundColor Red
+    }
     exit 1
 }
 


### PR DESCRIPTION
Closes #37.

## Summary

Fix the Windows installer so it can find `zv.exe` when the release zip puts the binary at the archive root.

The script still supports the previous nested layout:

```
zv-x86_64-pc-windows-msvc\zv.exe
```

and now also supports the current flat layout:

```
zv.exe
```

## Testing

Ran the installer locally on Windows:

```pwsh
zv on @fix/win-install
➜ ./scripts/install.ps1
=> Fetching latest version...
=> Installing zv v0.14.0 for x86_64-pc-windows-msvc...
=> Downloading zv-x86_64-pc-windows-msvc.zip...
=> Verifying checksum...
   Checksum verified
=> Extracting...
=> Installing to C:\Users\Kercy\.zv\bin...
   Binary installed to C:\Users\Kercy\.zv\bin\zv.exe
   Added C:\Users\Kercy\.zv\bin to user PATH

   zv v0.14.0 installed successfully!

  Binary:  C:\Users\Kercy\.zv\bin\zv.exe
  Data:    C:\Users\Kercy\.zv

  Next steps:
    zv setup    -- configure your shell environment
    zv sync     -- fetch zig indices and mirrors
    zv install  -- install a zig version
```